### PR TITLE
Matrix encoding of bit strings

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -17,6 +17,8 @@ jobs:
       run: |
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
+    - name : Fetch Dependency
+      run: git submodule update --init
     - name: Execute Tests
       run: make
     - name: Cleanup

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sha3"]
+	path = sha3
+	url = https://github.com/itzmeanjan/sha3.git

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CXX = g++
 CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
 OPTFLAGS = -O3 -march=native -mtune=native
 IFLAGS = -I ./include
+DEPFLAGS = -I ./sha3/include
 
 all: testing
 

--- a/include/encoding.hpp
+++ b/include/encoding.hpp
@@ -7,7 +7,9 @@ namespace encoding {
 
 // Given a bit string ( of length m x n x B -bits ) as byte array, this routine
 // encodes each B -bit wide sub-string as an integer k ∈ [0, 2^B), which is
-// encoded as an element of Zq s.t. q = 2^D and B <= D.
+// encoded as an element of Zq s.t. q = 2^D and B <= D using `ec()` function,
+// returning a matrix of dimension m x n over Zq, following algorithm 1 of
+// FrodoKEM specification.
 template<const size_t m, const size_t n, const uint32_t Q, const size_t B>
 inline void
 matrix_encode(
@@ -72,6 +74,79 @@ matrix_encode(
 
       boff += 1;
       moff += 2;
+    }
+  }
+}
+
+// Given a matrix of dimension m x n s.t. its elements ∈ Zq, this routine can be
+// used for decoding it into a bit string of length m x n x B -bits, extracting
+// B bits from most significant portion of each matrix entry, by applying `dc()`
+// function, returning a byte array of length (m x n x B)/ 8 -bytes, following
+// algorithm 2 of FrodoKEM specification.
+template<const size_t m, const size_t n, const uint32_t Q, const size_t B>
+inline void
+matrix_decode(
+  const zq::zq_t<Q>* const __restrict mat, // matrix of dimension m x n
+  uint8_t* const __restrict arr            // of length (m x n x B)/ 8 -bytes
+  )
+  requires((m == n) && frodo_params::check_q(Q) && frodo_params::check_b(B))
+{
+  if constexpr (B == 2) {
+    constexpr uint32_t mask = 0b11u;
+
+    size_t moff = 0;
+    size_t boff = 0;
+
+    while (moff < (m * n)) {
+      arr[boff] = ((mat[moff + 3].template decode<B>() & mask) << 6) |
+                  ((mat[moff + 2].template decode<B>() & mask) << 4) |
+                  ((mat[moff + 1].template decode<B>() & mask) << 2) |
+                  ((mat[moff + 0].template decode<B>() & mask) << 0);
+
+      moff += 4;
+      boff += 1;
+    }
+  } else if constexpr (B == 3) {
+    constexpr uint32_t mask3 = 0b111u;
+    constexpr uint32_t mask2 = 0b11u;
+    constexpr uint32_t mask1 = 0b1u;
+
+    size_t moff = 0;
+    size_t boff = 0;
+
+    while (moff < (m * n)) {
+      const auto t0 = mat[moff + 0].template decode<B>() & mask3;
+      const auto t1 = mat[moff + 1].template decode<B>() & mask3;
+      const auto t2 = mat[moff + 2].template decode<B>() & mask3;
+
+      arr[boff] = ((t2 & mask2) << 6) | (t1 << 3) | t0;
+
+      const auto t3 = mat[moff + 3].template decode<B>() & mask3;
+      const auto t4 = mat[moff + 4].template decode<B>() & mask3;
+      const auto t5 = mat[moff + 5].template decode<B>() & mask3;
+
+      arr[boff + 1] = ((t5 & mask1) << 7) | (t4 << 4) | (t3 << 1) | (t2 >> 2);
+
+      const auto t6 = mat[moff + 6].template decode<B>() & mask3;
+      const auto t7 = mat[moff + 7].template decode<B>() & mask3;
+
+      arr[boff + 2] = (t7 << 5) | (t6 << 2) | (t5 >> 1);
+
+      moff += 8;
+      boff += 3;
+    }
+  } else if constexpr (B == 4) {
+    constexpr uint32_t mask = 0b1111u;
+
+    size_t moff = 0;
+    size_t boff = 0;
+
+    while (moff < (m * n)) {
+      arr[boff] = ((mat[moff + 1].template decode<B>() & mask) << 4) |
+                  ((mat[moff + 0].template decode<B>() & mask) << 0);
+
+      moff += 2;
+      boff += 1;
     }
   }
 }

--- a/include/encoding.hpp
+++ b/include/encoding.hpp
@@ -1,0 +1,79 @@
+#pragma once
+#include "params.hpp"
+#include "zq.hpp"
+
+// Encoding bit strings to matrix and vice versa.
+namespace encoding {
+
+// Given a bit string ( of length m x n x B -bits ) as byte array, this routine
+// encodes each B -bit wide sub-string as an integer k ∈ [0, 2^B), which is
+// encoded as an element of Zq s.t. q = 2^D and B <= D.
+template<const size_t m, const size_t n, const uint32_t Q, const size_t B>
+inline void
+matrix_encode(
+  const uint8_t* const __restrict arr, // of length (m x n x B)/ 8 -bytes
+  zq::zq_t<Q>* const __restrict mat    // matrix of dimension m x n
+  )
+  requires((m == n) && frodo_params::check_q(Q) && frodo_params::check_b(B))
+{
+  // alias, so that I've to type lesser !
+  using Zq = zq::zq_t<Q>;
+
+  constexpr size_t bit_len = m * n * B;
+  constexpr size_t byte_len = bit_len / 8;
+
+  if constexpr (B == 2) {
+    constexpr uint8_t mask = 0b11;
+
+    size_t boff = 0;
+    size_t moff = 0;
+
+    while (boff < byte_len) {
+      mat[moff + 0] = Zq::template encode<B>((arr[boff] >> 0) & mask);
+      mat[moff + 1] = Zq::template encode<B>((arr[boff] >> 2) & mask);
+      mat[moff + 2] = Zq::template encode<B>((arr[boff] >> 4) & mask);
+      mat[moff + 3] = Zq::template encode<B>((arr[boff] >> 6) & mask);
+
+      boff += 1;
+      moff += 4;
+    }
+  } else if constexpr (B == 3) {
+    constexpr uint8_t mask3 = 0b111;
+    constexpr uint8_t mask2 = 0b11;
+    constexpr uint8_t mask1 = 0b1;
+
+    size_t boff = 0;
+    size_t moff = 0;
+
+    while (boff < byte_len) {
+      mat[moff + 0] = Zq::template encode<B>((arr[boff] >> 0) & mask3);
+      mat[moff + 1] = Zq::template encode<B>((arr[boff] >> 3) & mask3);
+      mat[moff + 2] = Zq::template encode<B>(((arr[boff + 1] & mask1) << 2) |
+                                             ((arr[boff] >> 6) & mask2));
+      mat[moff + 3] = Zq::template encode<B>((arr[boff + 1] >> 1) & mask3);
+      mat[moff + 4] = Zq::template encode<B>((arr[boff + 1] >> 4) & mask3);
+      mat[moff + 5] = Zq::template encode<B>(((arr[boff + 2] & mask2) << 1) |
+                                             ((arr[boff + 1] >> 7) & mask1));
+      mat[moff + 6] = Zq::template encode<B>((arr[boff + 2] >> 2) & mask3);
+      mat[moff + 7] = Zq::template encode<B>(arr[boff + 2] >> 5);
+
+      boff += 3;
+      moff += 8;
+    }
+  } else if constexpr (B == 4) {
+    constexpr uint8_t mask = 0b1111;
+
+    size_t boff = 0;
+    size_t moff = 0;
+
+    while (boff < byte_len) {
+      mat[moff + 0] = Zq::template encode<B>((arr[boff] >> 0) & mask);
+      mat[moff + 1] = Zq::template encode<B>((arr[boff] >> 4) & mask);
+
+      boff += 1;
+      moff += 2;
+    }
+  }
+}
+
+}

--- a/include/params.hpp
+++ b/include/params.hpp
@@ -14,4 +14,12 @@ check_q(const uint32_t q)
          && (q <= (1u << 16)); // and it must be <= 2^16
 }
 
+// Compile-time executable check for ensuring that FrodoKEM's parameter B only
+// takes arguments suggested on table 4 of FrodoKEM specification.
+constexpr bool
+check_b(const size_t b)
+{
+  return (b == 2) || (b == 3) || (b == 4);
+}
+
 }

--- a/include/prng.hpp
+++ b/include/prng.hpp
@@ -1,0 +1,62 @@
+#pragma once
+#include "shake128.hpp"
+#include <random>
+
+// Pseudo Random Number Generator
+namespace prng {
+
+// Pseudo Random Number Generator s.t. N (>0) -many random bytes are read
+// from SHAKE128 XOF state, by squeezing it arbitrary many times, s.t. SHAKE128
+// state is obtained by
+//
+// - either absorbing 32 -bytes, sampled using std::random_device ( default )
+// - or absorbing M(>0) -bytes, supplied as argument ( explicit )
+//
+// Note, std::random_device's behaviour is implementation defined feature, so
+// this PRNG implementation doesn't guarantee that it'll generate cryptographic
+// secure random bytes if you opt for using default constructor of this struct.
+//
+// I suggest you read
+// https://en.cppreference.com/w/cpp/numeric/random/random_device/random_device
+// before using default constructor. When using explicit constructor, it's
+// your responsibility to supply M -many random seed bytes.
+//
+// This implementation is taken from
+// https://github.com/itzmeanjan/dilithium/blob/6ac5eee0/include/prng.hpp
+struct prng_t
+{
+private:
+  shake128::shake128<false> state;
+
+public:
+  inline prng_t()
+  {
+    uint8_t seed[32];
+
+    // Read more @
+    // https://en.cppreference.com/w/cpp/numeric/random/random_device/random_device
+    std::random_device rd{};
+
+    size_t off = 0;
+    while (off < sizeof(seed)) {
+      const uint32_t v = rd();
+      std::memcpy(seed + off, &v, sizeof(v));
+
+      off += sizeof(v);
+    }
+
+    state.hash(seed, sizeof(seed));
+  }
+
+  inline explicit prng_t(const uint8_t* const seed, const size_t slen)
+  {
+    state.hash(seed, slen);
+  }
+
+  inline void read(uint8_t* const bytes, const size_t len)
+  {
+    state.read(bytes, len);
+  }
+};
+
+}

--- a/include/test/test_encoding.hpp
+++ b/include/test/test_encoding.hpp
@@ -1,0 +1,47 @@
+#pragma once
+#include "encoding.hpp"
+#include "prng.hpp"
+#include <cassert>
+#include <cstring>
+
+// Test functional correctness of FrodoKEM along with its components.
+namespace test_frodo {
+
+// Test if
+//
+// - encoding bit string of length m x n x B to matrix of dimension m x n
+// - decoding matrix of dimension m x n to bit string of length m x n x B
+//
+// works as expected.
+//
+// In other words, following test ensures that implementation of algorithm 1, 2
+// ( of FrodoKEM specification ) is correct for various parameters.
+template<const size_t m, const size_t n, const uint32_t Q, const size_t B>
+void
+test_matrix_encode_decode()
+{
+  constexpr size_t bit_len = m * n * B;
+  constexpr size_t byte_len = bit_len / 8;
+  constexpr size_t mat_len = sizeof(zq::zq_t<Q>) * m * n;
+
+  auto org_enc = static_cast<uint8_t*>(std::malloc(byte_len));
+  auto decoded = static_cast<zq::zq_t<Q>*>(std::malloc(mat_len));
+  auto fin_enc = static_cast<uint8_t*>(std::malloc(byte_len));
+
+  prng::prng_t prng;
+  prng.read(org_enc, byte_len);
+  std::memset(fin_enc, 0, byte_len);
+
+  encoding::matrix_encode<m, n, Q, B>(org_enc, decoded);
+  encoding::matrix_decode<m, n, Q, B>(decoded, fin_enc);
+
+  for (size_t i = 0; i < byte_len; i++) {
+    assert(org_enc[i] == fin_enc[i]);
+  }
+
+  std::free(org_enc);
+  std::free(decoded);
+  std::free(fin_enc);
+}
+
+}

--- a/include/test/test_frodo.hpp
+++ b/include/test/test_frodo.hpp
@@ -1,3 +1,4 @@
 #pragma once
 
+#include "test_encoding.hpp"
 #include "test_zq.hpp"

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,3 +1,4 @@
+#include "test/test_encoding.hpp"
 #include "test/test_frodo.hpp"
 #include <iostream>
 
@@ -11,6 +12,14 @@ main()
   test_frodo::test_zq_encode_decode<1u << 16, 3>();
   test_frodo::test_zq_encode_decode<1u << 16, 4>();
   std::cout << "[test] Encoding/ decoding of Zq elements\n";
+
+  test_frodo::test_matrix_encode_decode<8, 8, 1u << 15, 2>();
+  test_frodo::test_matrix_encode_decode<8, 8, 1u << 15, 3>();
+  test_frodo::test_matrix_encode_decode<8, 8, 1u << 15, 4>();
+  test_frodo::test_matrix_encode_decode<8, 8, 1u << 16, 2>();
+  test_frodo::test_matrix_encode_decode<8, 8, 1u << 16, 3>();
+  test_frodo::test_matrix_encode_decode<8, 8, 1u << 16, 4>();
+  std::cout << "[test] Encoding/ decoding of matrix over Zq\n";
 
   return 0;
 }


### PR DESCRIPTION
- [x] Implement algorithm 1, 2 of FrodoKEM specification
- [x] Ensure functional correctness of implementation by
  1. Create random bit string
  2. Use `encode()` for turning it into matrix of dimension \$m\$ x \$n\$
  3. Use `decode()` for converting matrix into a bit string of length \$m\$ x \$n\$ x \$B\$ -bits.

Run tests, by issuing

```bash
make
```